### PR TITLE
Enable options and Support for fonts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The default settings are the following :
 
 Each setting can be overwritten by passing them as an object to the `bower()` function.
 
+Any setting can also be set to `false` to prevent generation and output of those files.
+
 ### Examples
 
 ```javascript
@@ -85,3 +87,27 @@ Those examples do the same :
 - concat all js files in a `public/scripts/vendor.js` file
 - copy all webfonts in a `fonts/` folder.
 
+```javascript
+elixir(function(mix) {
+    mix.bower({
+        debugging: true,
+        css: false,
+        js: false,
+        font: {
+            output: 'public/fonts'
+        },
+        img: {
+            output: 'public/css',
+            extInline: ['gif', 'png'],   // Extensions to inline
+            maxInlineSize: 32 * 1024    // [kB] Inline as data uri images below specified size
+                                        // (use 0 to disable, max 32k on ie8)
+        }
+    });
+});
+```
+This example does the following:
+- scan your bower files
+- skips css and js files
+- copy all webfonts in a `public/fonts/` folder.
+- copy all gif or png images into `public/css` folder.
+- inline any of those images which are smaller than 32k.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This will :
 - concat all css files in a `public/css/vendor.css` file
 - concat all js files in a `public/js/vendor.js` file
 - copy all webfonts in a `fonts/` folder.
+- copy all images in a `imgs/` folder.
 
 ### Settings
 
@@ -38,6 +39,12 @@ The default settings are the following :
     },
     font: {
         output: 'public/fonts'      // Web fonts output folder
+    },
+    img: {
+        output: 'public/imgs',   
+        extInline: ['gif','png'],   // Extensions to inline
+        maxInlineSize: 32 * 1024    // [kB] Inline as data uri images below specified size
+                                    // (use 0 to disable, max 32k on ie8)
     }
 }
 ```
@@ -72,7 +79,7 @@ elixir(function(mix) {
 });
 ```
 
-Those examples doe the same :
+Those examples do the same :
 - scan your bower files
 - concat all css files in a `public/css/plugins.css` file
 - concat all js files in a `public/scripts/vendor.js` file

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The default settings are the following :
 ```javascript
 {
     debugging: false,               // Enable/Disable verbose output
+    flatten: true,                  // Enable/Disable flat asset structure 
     css: {
         file: 'vendor.css',         // Merged CSS file
         output: config.cssOutput    // Elixir default css output folder (public/css)
@@ -111,3 +112,34 @@ This example does the following:
 - copy all webfonts in a `public/fonts/` folder.
 - copy all gif or png images into `public/css` folder.
 - inline any of those images which are smaller than 32k.
+
+```javascript
+elixir(function(mix) {
+    mix.bower({
+        debugging: true,
+        flatten: false,
+        css: {
+            output: 'public/css'
+        },
+        js: false,
+        font: {
+            output: 'public/fonts'
+        },
+        img: {
+            output: 'public/imgs',
+            extInline: ['gif', 'png'],   // Extensions to inline
+            maxInlineSize: 32 * 1024    // [kB] Inline as data uri images below specified size
+                                        // (use 0 to disable, max 32k on ie8)
+        }
+    });
+});
+```
+This example does the following:
+- scan your bower files
+- deactivate flat asset mode
+- concat all css files in a `public/css/plugins.css` file
+- skips js files
+- copy all webfonts in a `public/fonts/{bower_package}/xxx` folder (according to bower package structure)
+- copy all gif or png images into `public/imgs/{bower_package}/xxx` folder (according to bower package structure)
+- inline any of those images which are smaller than 32k.
+

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The default settings are the following :
 
 ```javascript
 {
-    debug: false,                   // Enable/Disable verbose output
+    debugging: false,               // Enable/Disable verbose output
     css: {
         file: 'vendor.css',         // Merged CSS file
         output: config.cssOutput    // Elixir default css output folder (public/css)
@@ -49,7 +49,7 @@ Each setting can be overwritten by passing them as an object to the `bower()` fu
 ```javascript
 elixir(function(mix) {
     mix.bower({
-        debug: true,
+        debugging: true,
         css: {
             file: 'plugins.css'
         },
@@ -63,7 +63,7 @@ elixir(function(mix) {
 ```javascript
 
 var options = {};
-options.debug = true;
+options.debugging = true;
 options.css = {file: 'plugins.css'};
 options.js = {output: 'public/scripts'};
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ elixir(function(mix) {
 ```
 
 This will :
-    - scan your bower files
-    - concat all css files in a `public/css/vendor.css` file
-    - concat all js files in a `public/js/vendor.js` file
-    - copy all webfonts in a `fonts/` folder.
+- scan your bower files
+- concat all css files in a `public/css/vendor.css` file
+- concat all js files in a `public/js/vendor.js` file
+- copy all webfonts in a `fonts/` folder.
 
 ### Settings
 
@@ -73,8 +73,8 @@ elixir(function(mix) {
 ```
 
 Those examples doe the same :
-    - scan your bower files
-    - concat all css files in a `public/css/plugins.css` file
-    - concat all js files in a `public/scripts/vendor.js` file
-    - copy all webfonts in a `fonts/` folder.
+- scan your bower files
+- concat all css files in a `public/css/plugins.css` file
+- concat all js files in a `public/scripts/vendor.js` file
+- copy all webfonts in a `fonts/` folder.
 

--- a/README.md
+++ b/README.md
@@ -3,24 +3,78 @@ laravel-elixir-bower
 
 Elixir Wrapper Around Bower
 
-```
+### Usage
+
+```javascript
 var elixir = require('laravel-elixir');
 
 require('laravel-elixir-bower');
 
 elixir(function(mix) {
-    mix.bower()
-       .routes()
-       .events();
+    mix.bower();
 });
 ```
 
-This will scan your bower files and concat all css files, by default, in a `css/vendor.css` file. And all js files in a `js/vendor.js` file.
+This will :
+    - scan your bower files
+    - concat all css files in a `public/css/vendor.css` file
+    - concat all js files in a `public/js/vendor.js` file
+    - copy all webfonts in a `fonts/` folder.
 
-These settings can be overwriten by passing them to the `bower()` function.
+### Settings
 
+The default settings are the following :
+
+```javascript
+{
+    debug: false,                   // Enable/Disable verbose output
+    css: {
+        file: 'vendor.css',         // Merged CSS file
+        output: config.cssOutput    // Elixir default css output folder (public/css)
+    },
+    js: {
+        file: 'vendor.js',          // Merged JS file
+        output: config.jsOutput     // Elixir default js output folder (public/js)
+    },
+    font: {
+        output: 'public/fonts'      // Web fonts output folder
+    }
+}
 ```
+
+Each setting can be overwritten by passing them as an object to the `bower()` function.
+
+### Examples
+
+```javascript
 elixir(function(mix) {
-    mix.bower('styles.css', 'public/assets/css', 'scripts.js', 'public/assets/js');
+    mix.bower({
+        debug: true,
+        css: {
+            file: 'plugins.css'
+        },
+        js: {
+            output: 'public/scripts'
+        }
+    });
 });
 ```
+
+```javascript
+
+var options = {};
+options.debug = true;
+options.css = {file: 'plugins.css'};
+options.js = {output: 'public/scripts'};
+
+elixir(function(mix) {
+    mix.bower(options);
+});
+```
+
+Those examples doe the same :
+    - scan your bower files
+    - concat all css files in a `public/css/plugins.css` file
+    - concat all js files in a `public/scripts/vendor.js` file
+    - copy all webfonts in a `fonts/` folder.
+

--- a/index.js
+++ b/index.js
@@ -21,10 +21,12 @@ elixir.extend('bower', function (options) {
     var options = _.merge({
         debugging: false,
         css: {
+            minify : true,
             file: 'vendor.css',
             output: config.cssOutput ? config.cssOutput : config.publicDir + '/css'
         },
         js: {
+            uglify : true,
             file: 'vendor.js',
             output: config.jsOutput ? config.jsOutput : config.publicDir + '/js'
         },
@@ -61,7 +63,7 @@ elixir.extend('bower', function (options) {
                 debug: options.debugging,
             })))
             .pipe(concat(options.css.file))
-            .pipe(minify())
+            .pipe(test(options.css.minify,minify()))
             .pipe(gulp.dest(options.css.output))
             .pipe(notify({
                 title: 'Laravel Elixir',
@@ -89,7 +91,7 @@ elixir.extend('bower', function (options) {
             .on('error', onError)
             .pipe(filter('**/*.js'))
             .pipe(concat(options.js.file))
-            .pipe(uglify())
+            .pipe(test(options.js.uglify,uglify()))
             .pipe(gulp.dest(options.js.output))
             .pipe(notify({
                 title: 'Laravel Elixir',

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ elixir.extend('bower', function(options) {
         
         return gulp.src(mainBowerFiles({
                 debugging: options.debugging,
-                filter: (/\.(eot|svg|ttf|woff|otf)$/i)
+                filter: (/\.(eot|svg|ttf|woff|woff2|otf)$/i)
             }))
             .on('error', onError)
             .pipe(gulp.dest(options.font.output))

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ elixir.extend('bower', function (options) {
             notify.onError({
                 title: "Laravel Elixir",
                 subtitle: "Bower Files CSS Compilation Failed!",
-                message: "Error: <%= error.message %>",
+                message: "Bower Files CSS Compilation Failed! Error: <%= error.message %>",
                 icon: __dirname + '/../icons/fail.png'
             })(err);
 
@@ -80,7 +80,7 @@ elixir.extend('bower', function (options) {
                 title: 'Laravel Elixir',
                 subtitle: 'CSS Bower Files Imported!',
                 icon: __dirname + '/../icons/laravel.png',
-                message: ' '
+                message: 'CSS Bower Files Imported!'
             }));
 
     });
@@ -91,7 +91,7 @@ elixir.extend('bower', function (options) {
             notify.onError({
                 title: "Laravel Elixir",
                 subtitle: "Bower Files JS Compilation Failed!",
-                message: "Error: <%= error.message %>",
+                message: "Bower Files JS Compilation Failed! Error: <%= error.message %>",
                 icon: __dirname + '/../icons/fail.png'
             })(err);
 
@@ -108,7 +108,7 @@ elixir.extend('bower', function (options) {
                 title: 'Laravel Elixir',
                 subtitle: 'Javascript Bower Files Imported!',
                 icon: __dirname + '/../icons/laravel.png',
-                message: ' '
+                message: 'Javascript Bower Files Imported!'
             }));
 
     });
@@ -120,7 +120,7 @@ elixir.extend('bower', function (options) {
             notify.onError({
                 title: "Laravel Elixir",
                 subtitle: "Bower Files Font Copy Failed!",
-                message: "Error: <%= error.message %>",
+                message: "Bower Files Font Copy Failed! Error: <%= error.message %>",
                 icon: __dirname + '/../icons/fail.png'
             })(err);
 
@@ -138,7 +138,7 @@ elixir.extend('bower', function (options) {
                 title: 'Laravel Elixir',
                 subtitle: 'Font Bower Files Imported!',
                 icon: __dirname + '/../icons/laravel.png',
-                message: ' '
+                message: 'Font Bower Files Imported!'
             }));
     });
 
@@ -149,7 +149,7 @@ elixir.extend('bower', function (options) {
             notify.onError({
                 title: "Laravel Elixir",
                 subtitle: "Bower Files Images Copy Failed!",
-                message: "Error: <%= error.message %>",
+                message: "Bower Files Images Copy Failed! Error: <%= error.message %>",
                 icon: __dirname + '/../icons/fail.png'
             })(err);
 
@@ -179,9 +179,8 @@ elixir.extend('bower', function (options) {
             .pipe(gulp.dest(options.img.output))
             .pipe(notify({
                 title: 'Laravel Elixir',
-                subtitle: 'Images Bower Files Imported!',
                 icon: __dirname + '/../icons/laravel.png',
-                message: ' '
+                message:  'Images Bower Files Imported!'
             }));
 
     });

--- a/index.js
+++ b/index.js
@@ -6,14 +6,28 @@ var notify = require('gulp-notify');
 var minify = require('gulp-minify-css');
 var uglify = require('gulp-uglify');
 var concat = require('gulp-concat');
+var _ = require('lodash');
 
-elixir.extend('bower', function(cssFile, cssOutput, jsFile, jsOutput) {
+elixir.extend('bower', function(options) {
 
     var config = this;
-    var cssFile = cssFile || 'vendor.css';
-    var jsFile = jsFile || 'vendor.js';
+    
+    var options = _.merge({
+        debug: false,
+        css: {
+            file: 'vendor.css',
+            output: config.cssOutput
+        },
+        js: {
+            file: 'vendor.js',
+            output: config.jsOutput
+        },
+        font: {
+            output: 'public/fonts'
+        }
+    }, options);
 
-    gulp.task('bower', ['bower-css', 'bower-js']);
+    gulp.task('bower', ['bower-css', 'bower-js', 'bower-fonts']);
 
     gulp.task('bower-css', function () {
         var onError = function (err) {
@@ -27,12 +41,12 @@ elixir.extend('bower', function(cssFile, cssOutput, jsFile, jsOutput) {
             this.emit('end');
         };
 
-        return gulp.src(mainBowerFiles())
+        return gulp.src(mainBowerFiles({debugging: options.debug}))
             .on('error', onError)
             .pipe(filter('**/*.css'))
-            .pipe(concat(cssFile))
+            .pipe(concat(options.css.file))
             .pipe(minify())
-            .pipe(gulp.dest(cssOutput || config.cssOutput))
+            .pipe(gulp.dest(options.css.output))
             .pipe(notify({
                 title: 'Laravel Elixir',
                 subtitle: 'CSS Bower Files Imported!',
@@ -55,12 +69,12 @@ elixir.extend('bower', function(cssFile, cssOutput, jsFile, jsOutput) {
             this.emit('end');
         };
 
-        return gulp.src(mainBowerFiles())
+        return gulp.src(mainBowerFiles({debugging: options.debug}))
             .on('error', onError)
             .pipe(filter('**/*.js'))
-            .pipe(concat(jsFile))
+            .pipe(concat(options.js.file))
             .pipe(uglify())
-            .pipe(gulp.dest(jsOutput || config.jsOutput))
+            .pipe(gulp.dest(options.js.output))
             .pipe(notify({
                 title: 'Laravel Elixir',
                 subtitle: 'Javascript Bower Files Imported!',
@@ -69,6 +83,35 @@ elixir.extend('bower', function(cssFile, cssOutput, jsFile, jsOutput) {
             }));
 
     });
+    
+    gulp.task('bower-fonts', function(){
+        
+        var onError = function (err) {
+
+            notify.onError({
+                title: "Laravel Elixir",
+                subtitle: "Bower Files Font Copy Failed!",
+                message: "Error: <%= error.message %>",
+                icon: __dirname + '/../icons/fail.png'
+            })(err);
+
+            this.emit('end');
+        };
+        
+        return gulp.src(mainBowerFiles({
+                debugging: options.debug,
+                filter: (/\.(eot|svg|ttf|woff|otf)$/i)
+            }))
+            .on('error', onError)
+            .pipe(gulp.dest(options.font.output))
+            .pipe(notify({
+                title: 'Laravel Elixir',
+                subtitle: 'Font Bower Files Imported!',
+                icon: __dirname + '/../icons/laravel.png',
+                message: ' '
+            }));
+    });
+    
 
     return this.queueTask('bower');
 

--- a/index.js
+++ b/index.js
@@ -12,29 +12,30 @@ var test = require('gulp-if');
 var ignore = require('gulp-ignore');
 var getFileSize = require("filesize");
 
+var config = elixir.config;
+
+
 var _ = require('lodash');
 
 elixir.extend('bower', function (options) {
 
-    var config = this;
-    
     var options = _.merge({
         debugging: false,
         css: {
             minify : true,
             file: 'vendor.css',
-            output: config.cssOutput ? config.cssOutput : config.publicDir + '/css'
+            output: config.css.outputFolder ? config.css.outputFolder : config.publicPath + '/css'
         },
         js: {
             uglify : true,
             file: 'vendor.js',
-            output: config.jsOutput ? config.jsOutput : config.publicDir + '/js'
+            output: config.js.outputFolder ? config.js.outputFolder : config.publicPath + '/js'
         },
         font: {
-            output: config.fontOutput ? config.fontOutput : config.publicDir + '/fonts'
+            output: config.font.outputFolder ? config.font.outputFolder : config.publicPath + '/fonts'
         },
         img: {
-            output: config.imgOutput ? config.imgOutput : config.publicDir + '/imgs',
+            output: config.img.outputFolder ? config.img.outputFolder : config.publicPath + '/imgs',
             extInline: ['gif', 'png'],
             maxInlineSize: 32 * 1024 //max 32k on ie8
         }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,14 @@ elixir.extend('bower', function(options) {
         }
     }, options);
 
-    gulp.task('bower', ['bower-css', 'bower-js', 'bower-fonts', 'bower-imgs']);
+    var files = [];
+
+    if(options.css  !== false) files.push('bower-css');
+    if(options.js   !== false) files.push('bower-js');
+    if(options.font !== false) files.push('bower-fonts');
+    if(options.img  !== false) files.push('bower-imgs');
+
+    gulp.task('bower', files );
 
     gulp.task('bower-css', function () {
         var onError = function (err) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var changed = require('gulp-changed');
 var base64 = require('gulp-base64');
 var test = require('gulp-if');
 var ignore = require('gulp-ignore');
-var getFileSize = require("filesize");
+var filesize = require('filesize');
 
 var task = elixir.Task;
 var config = elixir.config;
@@ -143,15 +143,15 @@ elixir.extend('bower', function (options) {
 
         var isInline = function (file) {
             
-            var filesize = file.stat ? getFileSize(file.stat.size) : getFileSize(Buffer.byteLength(String(file.contents)));
-            var fileext = file.path.split('.').pop();
+            var fsize = file.stat ? filesize(file.stat.size) : filesize(Buffer.byteLength(String(file.contents)));
+            var fext = file.path.split('.').pop();
             
             if (options.debugging)
             {
-                console.log("Size of file:" + file.path + " (" + 1024*parseFloat(filesize) +" / max="+options.img.maxInlineSize+")");
+                console.log("Size of file:" + file.path + " (" + 1024*parseFloat(fsize) +" / max="+options.img.maxInlineSize+")");
             }
             
-            return options.img.extInline.indexOf(fileext) > -1 && 1024*parseFloat(filesize) < options.img.maxInlineSize;
+            return options.img.extInline.indexOf(fext) > -1 && 1024*parseFloat(fsize) < options.img.maxInlineSize;
         }
 
         return gulp.src(mainBowerFiles({

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var filesize = require('filesize');
 
 var task = elixir.Task;
 var config = elixir.config;
+var notification = elixir.Notification;
 
 
 var _ = require('lodash');
@@ -76,7 +77,7 @@ elixir.extend('bower', function (options) {
             .pipe(concat(options.css.file))
             .pipe(test(options.css.minify,minify()))
             .pipe(gulp.dest(options.css.output))
-            .pipe(new elixir.Notification('CSS Bower Files Imported!'));
+            .pipe(new notification('CSS Bower Files Imported!'));
 
     });
 
@@ -99,7 +100,7 @@ elixir.extend('bower', function (options) {
             .pipe(concat(options.js.file))
             .pipe(test(options.js.uglify,uglify()))
             .pipe(gulp.dest(options.js.output))
-            .pipe(new elixir.Notification('Javascript Bower Files Imported!'));
+            .pipe(new notification('Javascript Bower Files Imported!'));
 
     });
     
@@ -124,7 +125,7 @@ elixir.extend('bower', function (options) {
             .on('error', onError)
             .pipe(changed(options.font.output))
             .pipe(gulp.dest(options.font.output))
-            .pipe(new elixir.Notification('Font Bower Files Imported!'));
+            .pipe(new notification('Font Bower Files Imported!'));
     });
 
     gulp.task('bower-imgs', function () {
@@ -162,7 +163,7 @@ elixir.extend('bower', function (options) {
             .pipe(ignore.exclude(isInline)) // Exclude inlined images
             .pipe(changed(options.img.output))
             .pipe(gulp.dest(options.img.output))
-            .pipe(new elixir.Notification('Images Bower Files Imported!'));
+            .pipe(new notification('Images Bower Files Imported!'));
 
     });
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var getFileSize = require("filesize");
 
 var _ = require('lodash');
 
-elixir.extend('bower', function(options) {
+elixir.extend('bower', function (options) {
 
     var config = this;
     
@@ -22,18 +22,18 @@ elixir.extend('bower', function(options) {
         debugging: false,
         css: {
             file: 'vendor.css',
-            output: config.cssOutput
+            output: config.cssOutput ? config.cssOutput : config.publicDir + '/css'
         },
         js: {
             file: 'vendor.js',
-            output: config.jsOutput
+            output: config.jsOutput ? config.jsOutput : config.publicDir + '/js'
         },
         font: {
-            output: 'public/fonts'
+            output: config.fontOutput ? config.fontOutput : config.publicDir + '/fonts'
         },
         img: {
-            output: 'public/imgs',
-            extInline: [ 'gif', 'png'],
+            output: config.imgOutput ? config.imgOutput : config.publicDir + '/imgs',
+            extInline: ['gif', 'png'],
             maxInlineSize: 32 * 1024 //max 32k on ie8
         }
     }, options);

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var test = require('gulp-if');
 var ignore = require('gulp-ignore');
 var getFileSize = require("filesize");
 
+var task = elixir.Task;
 var config = elixir.config;
 
 
@@ -175,8 +176,9 @@ elixir.extend('bower', function (options) {
             }));
 
     });
-    
 
-    return this.queueTask('bower');
+    new task('bower',function(){
+        return gulp.start('bower');
+    });
 
 });

--- a/index.js
+++ b/index.js
@@ -25,18 +25,18 @@ elixir.extend('bower', function (options) {
         css: {
             minify : true,
             file: 'vendor.css',
-            output: config.css.outputFolder ? config.css.outputFolder : config.publicPath + '/css'
+            output: config.css.outputFolder ? config.publicPath + '/' + config.css.outputFolder : config.publicPath + '/css'
         },
         js: {
             uglify : true,
             file: 'vendor.js',
-            output: config.js.outputFolder ? config.js.outputFolder : config.publicPath + '/js'
+            output: config.js.outputFolder ? config.publicPath + '/' + config.js.outputFolder : config.publicPath + '/js'
         },
         font: {
-            output: (config.font && config.font.outputFolder) ? config.font.outputFolder : config.publicPath + '/fonts'
+            output: (config.font && config.font.outputFolder) ? config.publicPath + '/' + config.font.outputFolder : config.publicPath + '/fonts'
         },
         img: {
-            output: (config.img && config.img.outputFolder) ? config.img.outputFolder : config.publicPath + '/imgs',
+            output: (config.img && config.img.outputFolder) ? config.publicPath + '/' + config.img.outputFolder : config.publicPath + '/imgs',
             extInline: ['gif', 'png'],
             maxInlineSize: 32 * 1024 //max 32k on ie8
         }
@@ -49,7 +49,9 @@ elixir.extend('bower', function (options) {
     if(options.font !== false) files.push('bower-fonts');
     if(options.img  !== false) files.push('bower-imgs');
 
-    gulp.task('bower', files );
+    new task('bower', function () {
+        return gulp.start(files);
+    });
 
     gulp.task('bower-css', function () {
         var onError = function (err) {
@@ -182,10 +184,6 @@ elixir.extend('bower', function (options) {
                 message: ' '
             }));
 
-    });
-
-    new task('bower',function(){
-        return gulp.start('bower');
     });
 
 });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp');
-var mainBowerFiles = require('main-bower-files');
+var bowerfiles = require('main-bower-files');
 var elixir = require('laravel-elixir');
 var filter = require('gulp-filter');
 var notify = require('gulp-notify');
@@ -65,7 +65,7 @@ elixir.extend('bower', function (options) {
             this.emit('end');
         };
 
-        return gulp.src(mainBowerFiles({debugging: options.debugging}))
+        return gulp.src(bowerfiles({debugging: options.debugging}))
             .on('error', onError)
             .pipe(filter('**/*.css'))
             .pipe(test(options.img.maxInlineSize > 0, base64({
@@ -93,7 +93,7 @@ elixir.extend('bower', function (options) {
             this.emit('end');
         };
 
-        return gulp.src(mainBowerFiles({debugging: options.debugging}))
+        return gulp.src(bowerfiles({debugging: options.debugging}))
             .on('error', onError)
             .pipe(filter('**/*.js'))
             .pipe(concat(options.js.file))
@@ -117,7 +117,7 @@ elixir.extend('bower', function (options) {
             this.emit('end');
         };
  
-        return gulp.src(mainBowerFiles({
+        return gulp.src(bowerfiles({
                 debugging: options.debugging,
                 filter: (/\.(eot|svg|ttf|woff|woff2|otf)$/i)
             }))
@@ -154,7 +154,7 @@ elixir.extend('bower', function (options) {
             return options.img.extInline.indexOf(fext) > -1 && 1024*parseFloat(fsize) < options.img.maxInlineSize;
         }
 
-        return gulp.src(mainBowerFiles({
+        return gulp.src(bowerfiles({
             debugging: options.debugging,
             filter: (/\.(png|bmp|gif|jpg|jpeg)$/i)
             }))

--- a/index.js
+++ b/index.js
@@ -76,12 +76,7 @@ elixir.extend('bower', function (options) {
             .pipe(concat(options.css.file))
             .pipe(test(options.css.minify,minify()))
             .pipe(gulp.dest(options.css.output))
-            .pipe(notify({
-                title: 'Laravel Elixir',
-                subtitle: 'CSS Bower Files Imported!',
-                icon: __dirname + '/../icons/laravel.png',
-                message: 'CSS Bower Files Imported!'
-            }));
+            .pipe(new elixir.Notification('CSS Bower Files Imported!'));
 
     });
 
@@ -104,12 +99,7 @@ elixir.extend('bower', function (options) {
             .pipe(concat(options.js.file))
             .pipe(test(options.js.uglify,uglify()))
             .pipe(gulp.dest(options.js.output))
-            .pipe(notify({
-                title: 'Laravel Elixir',
-                subtitle: 'Javascript Bower Files Imported!',
-                icon: __dirname + '/../icons/laravel.png',
-                message: 'Javascript Bower Files Imported!'
-            }));
+            .pipe(new elixir.Notification('Javascript Bower Files Imported!'));
 
     });
     
@@ -126,7 +116,7 @@ elixir.extend('bower', function (options) {
 
             this.emit('end');
         };
-        
+ 
         return gulp.src(mainBowerFiles({
                 debugging: options.debugging,
                 filter: (/\.(eot|svg|ttf|woff|woff2|otf)$/i)
@@ -134,12 +124,7 @@ elixir.extend('bower', function (options) {
             .on('error', onError)
             .pipe(changed(options.font.output))
             .pipe(gulp.dest(options.font.output))
-            .pipe(notify({
-                title: 'Laravel Elixir',
-                subtitle: 'Font Bower Files Imported!',
-                icon: __dirname + '/../icons/laravel.png',
-                message: 'Font Bower Files Imported!'
-            }));
+            .pipe(new elixir.Notification('Font Bower Files Imported!'));
     });
 
     gulp.task('bower-imgs', function () {
@@ -177,11 +162,7 @@ elixir.extend('bower', function (options) {
             .pipe(ignore.exclude(isInline)) // Exclude inlined images
             .pipe(changed(options.img.output))
             .pipe(gulp.dest(options.img.output))
-            .pipe(notify({
-                title: 'Laravel Elixir',
-                icon: __dirname + '/../icons/laravel.png',
-                message:  'Images Bower Files Imported!'
-            }));
+            .pipe(new elixir.Notification('Images Bower Files Imported!'));
 
     });
 

--- a/index.js
+++ b/index.js
@@ -33,10 +33,10 @@ elixir.extend('bower', function (options) {
             output: config.js.outputFolder ? config.js.outputFolder : config.publicPath + '/js'
         },
         font: {
-            output: config.font.outputFolder ? config.font.outputFolder : config.publicPath + '/fonts'
+            output: (config.font && config.font.outputFolder) ? config.font.outputFolder : config.publicPath + '/fonts'
         },
         img: {
-            output: config.img.outputFolder ? config.img.outputFolder : config.publicPath + '/imgs',
+            output: (config.img && config.img.outputFolder) ? config.img.outputFolder : config.publicPath + '/imgs',
             extInline: ['gif', 'png'],
             maxInlineSize: 32 * 1024 //max 32k on ie8
         }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ var minify = require('gulp-minify-css');
 var uglify = require('gulp-uglify');
 var concat = require('gulp-concat');
 var changed = require('gulp-changed');
+var base64 = require('gulp-base64');
+var test = require('gulp-if');
+var ignore = require('gulp-ignore');
+var getFileSize = require("filesize");
+
 var _ = require('lodash');
 
 elixir.extend('bower', function(options) {
@@ -25,10 +30,15 @@ elixir.extend('bower', function(options) {
         },
         font: {
             output: 'public/fonts'
+        },
+        img: {
+            output: 'public/imgs',
+            extInline: [ 'gif', 'png'],
+            maxInlineSize: 32 * 1024 //max 32k on ie8
         }
     }, options);
 
-    gulp.task('bower', ['bower-css', 'bower-js', 'bower-fonts']);
+    gulp.task('bower', ['bower-css', 'bower-js', 'bower-fonts', 'bower-imgs']);
 
     gulp.task('bower-css', function () {
         var onError = function (err) {
@@ -45,6 +55,11 @@ elixir.extend('bower', function(options) {
         return gulp.src(mainBowerFiles({debugging: options.debugging}))
             .on('error', onError)
             .pipe(filter('**/*.css'))
+            .pipe(test(options.img.maxInlineSize > 0, base64({
+                extensions: options.img.extInline,
+                maxImageSize: options.img.maxInlineSize, // bytes 
+                debug: options.debugging,
+            })))
             .pipe(concat(options.css.file))
             .pipe(minify())
             .pipe(gulp.dest(options.css.output))
@@ -112,6 +127,50 @@ elixir.extend('bower', function(options) {
                 icon: __dirname + '/../icons/laravel.png',
                 message: ' '
             }));
+    });
+
+    gulp.task('bower-imgs', function () {
+
+        var onError = function (err) {
+
+            notify.onError({
+                title: "Laravel Elixir",
+                subtitle: "Bower Files Images Copy Failed!",
+                message: "Error: <%= error.message %>",
+                icon: __dirname + '/../icons/fail.png'
+            })(err);
+
+            this.emit('end');
+        };
+
+        var isInline = function (file) {
+            
+            var filesize = file.stat ? getFileSize(file.stat.size) : getFileSize(Buffer.byteLength(String(file.contents)));
+            var fileext = file.path.split('.').pop();
+            
+            if (options.debugging)
+            {
+                console.log("Size of file:" + file.path + " (" + 1024*parseFloat(filesize) +" / max="+options.img.maxInlineSize+")");
+            }
+            
+            return options.img.extInline.indexOf(fileext) > -1 && 1024*parseFloat(filesize) < options.img.maxInlineSize;
+        }
+
+        return gulp.src(mainBowerFiles({
+            debugging: options.debugging,
+            filter: (/\.(png|bmp|gif|jpg|jpeg)$/i)
+            }))
+            .on('error', onError)
+            .pipe(ignore.exclude(isInline)) // Exclude inlined images
+            .pipe(changed(options.img.output))
+            .pipe(gulp.dest(options.img.output))
+            .pipe(notify({
+                title: 'Laravel Elixir',
+                subtitle: 'Images Bower Files Imported!',
+                icon: __dirname + '/../icons/laravel.png',
+                message: ' '
+            }));
+
     });
     
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ elixir.extend('bower', function(options) {
     var config = this;
     
     var options = _.merge({
-        debug: false,
+        debugging: false,
         css: {
             file: 'vendor.css',
             output: config.cssOutput
@@ -41,7 +41,7 @@ elixir.extend('bower', function(options) {
             this.emit('end');
         };
 
-        return gulp.src(mainBowerFiles({debugging: options.debug}))
+        return gulp.src(mainBowerFiles({debugging: options.debugging}))
             .on('error', onError)
             .pipe(filter('**/*.css'))
             .pipe(concat(options.css.file))
@@ -69,7 +69,7 @@ elixir.extend('bower', function(options) {
             this.emit('end');
         };
 
-        return gulp.src(mainBowerFiles({debugging: options.debug}))
+        return gulp.src(mainBowerFiles({debugging: options.debugging}))
             .on('error', onError)
             .pipe(filter('**/*.js'))
             .pipe(concat(options.js.file))
@@ -99,7 +99,7 @@ elixir.extend('bower', function(options) {
         };
         
         return gulp.src(mainBowerFiles({
-                debugging: options.debug,
+                debugging: options.debugging,
                 filter: (/\.(eot|svg|ttf|woff|otf)$/i)
             }))
             .on('error', onError)

--- a/index.js
+++ b/index.js
@@ -11,11 +11,13 @@ var base64 = require('gulp-base64');
 var test = require('gulp-if');
 var ignore = require('gulp-ignore');
 var filesize = require('filesize');
+var rework = require('rework');		 
+var path = require('path');		
+var validator = require('validator');
 
 var task = elixir.Task;
 var config = elixir.config;
 var notification = elixir.Notification;
-
 
 var _ = require('lodash');
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var notify = require('gulp-notify');
 var minify = require('gulp-minify-css');
 var uglify = require('gulp-uglify');
 var concat = require('gulp-concat');
+var changed = require('gulp-changed');
 var _ = require('lodash');
 
 elixir.extend('bower', function(options) {
@@ -103,6 +104,7 @@ elixir.extend('bower', function(options) {
                 filter: (/\.(eot|svg|ttf|woff|woff2|otf)$/i)
             }))
             .on('error', onError)
+            .pipe(changed(options.font.output))
             .pipe(gulp.dest(options.font.output))
             .pipe(notify({
                 title: 'Laravel Elixir',

--- a/package.json
+++ b/package.json
@@ -23,21 +23,23 @@
     "url": "https://github.com/Crinsane/laravel-elixir-bower/issues"
   },
   "dependencies": {
-    "gulp-changed": "^1.1.1",
-    "gulp-concat": "^2.4.1",
-    "gulp-filter": "^1.0.2",
-    "gulp-load-plugins": "^0.7.0",
-    "gulp-minify-css": "^0.3.11",
-    "gulp-notify": "^2.0.0",
-    "gulp-uglify": "^1.0.1",
-    "lodash": "^3.0.1",
-    "main-bower-files": "^2.1.0",
-    "gulp-base64" :"^0.1.2",
-    "gulp-if" :"^1.2.5",
-    "gulp-ignore" :"^1.2.1",
-    "filesize":"^2.0.0",
-    "rework": "^0.20.2",
-    "validator": "^3.1.0"
+    "gulp-changed": "^1.1",
+    "gulp-concat": "^2.4",
+    "gulp-filter": "^1.0",
+    "gulp-load-plugins": "^0.7",
+    "gulp-minify-css": "^0.3",
+    "gulp-notify": "^2.0",
+    "gulp-uglify": "^1.0",
+    "lodash": "^3.0",
+    "main-bower-files": "^2.1",
+    "gulp-base64" :"^0.1",
+    "gulp-if" :"^1.2",
+    "gulp-ignore" :"^1.2",
+    "gulp-rewrite-css":"^0.0",
+    "filesize":"^2.0",
+    "validator": "^4.2",
+    "is-absolute-url":"^2.0"
+    
   },
   "peerDependencies":{
     "laravel-elixir":"^3.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/Crinsane/laravel-elixir-bower/issues"
   },
   "dependencies": {
+    "gulp-changed": "^1.1.1",
     "gulp-concat": "^2.4.1",
     "gulp-filter": "^1.0.2",
     "gulp-load-plugins": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "gulp-notify": "^2.0.0",
     "gulp-uglify": "^1.0.1",
     "lodash": "^3.0.1",
-    "main-bower-files": "^2.1.0"
+    "main-bower-files": "^2.1.0",
+    "gulp-base64" :"^0.1.2",
+    "gulp-if" :"^1.2.5",
+    "gulp-ignore" :"^1.2.1",
+    "filesize":"^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "gulp-base64" :"^0.1.2",
     "gulp-if" :"^1.2.5",
     "gulp-ignore" :"^1.2.1",
-    "filesize":"^2.0.0"
+    "filesize":"^2.0.0",
+    "rework": "^0.20.2",
+    "validator": "^3.1.0"
   },
   "peerDependencies":{
     "laravel-elixir":"^3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-elixir-bower",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Laravel Elixir Bower Extension",
   "main": "index.js",
   "scripts": {
@@ -36,5 +36,8 @@
     "gulp-if" :"^1.2.5",
     "gulp-ignore" :"^1.2.1",
     "filesize":"^2.0.0"
+  },
+  "peerDependencies":{
+    "laravel-elixir":"^2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-minify-css": "^0.3.11",
     "gulp-notify": "^2.0.0",
     "gulp-uglify": "^1.0.1",
+    "lodash": "^3.0.1",
     "main-bower-files": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-elixir-bower",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Laravel Elixir Bower Extension",
   "main": "index.js",
   "scripts": {
@@ -38,6 +38,6 @@
     "filesize":"^2.0.0"
   },
   "peerDependencies":{
-    "laravel-elixir":"^2.0"
+    "laravel-elixir":"^3.0"
   }
 }


### PR DESCRIPTION
I needed to publish fonts from my bower file (ie: font-awesome) So I added a new gulp task.

Then I realized I needed some extra-options in order to export the font files where needed.

I was not really fan of adding an extra parameter, so I refactor the options handling and used [lodash](https://lodash.com/docs#merge) to recursively merge an option object. 
This is not backward compliant, but really convenient when you just need to overwrite only one option.
